### PR TITLE
feat(release): support exact in-PR version overrides

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -143,7 +143,7 @@ jobs:
           $marker
           Release version selected: **$VERSION**.
 
-          This release will be performed as **$VERSION**. To change it, edit this PR title to \\`release: X.Y.Z\\` (including any prerelease suffix); the workflow will update the release files in place.
+          This release will be performed as **$VERSION**. To change it, edit this PR title to release: X.Y.Z (including any prerelease suffix); the workflow will update the release files in place.
           EOF
           )
           existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -75,6 +75,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
           git fetch origin main
           changed=$(git diff --name-only --diff-filter=AM "origin/main...HEAD")
           rewritten=()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,29 +77,33 @@ jobs:
           set -euo pipefail
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
           git fetch origin main
+          current=$(jq -r '."."' .release-please-manifest.json)
+          if [ -z "$current" ] || [ "$current" = "null" ]; then
+            echo "::error::Could not determine the current release version"
+            exit 1
+          fi
           changed=$(git diff --name-only --diff-filter=AM "origin/main...HEAD")
           rewritten=()
           while IFS= read -r file; do
             [ -n "$file" ] || continue
             [ -f "$file" ] || continue
             grep -Iq . "$file" || continue
-            DESIRED_VERSION="$VERSION" python3 - "$file" <<'PY'
+            CURRENT_VERSION="$current" DESIRED_VERSION="$VERSION" python3 - "$file" <<'PY'
           import os
           import re
           import sys
 
           path = sys.argv[1]
+          old = os.environ["CURRENT_VERSION"]
           new = os.environ["DESIRED_VERSION"]
           version_pattern = re.compile(
-              r"(?<![0-9.])[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?![0-9.])"
+              r"(?<![0-9.])" + re.escape(old) + r"(?![0-9.])"
           )
           with open(path, encoding="utf-8") as handle:
               contents = handle.read()
-          match = version_pattern.search(contents)
-          if match is None:
+          if version_pattern.search(contents) is None:
               sys.exit(0)
-          old = match.group(0)
-          updated = contents.replace(old, new)
+          updated = version_pattern.sub(new, contents)
           if updated != contents:
               with open(path, "w", encoding="utf-8") as handle:
                   handle.write(updated)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,32 +76,33 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
-          current=$(jq -r '."."' .release-please-manifest.json)
-          if [ -z "$current" ] || [ "$current" = "null" ]; then
-            echo "::error::Could not determine the current release version"
-            exit 1
-          fi
-
           changed=$(git diff --name-only --diff-filter=AM "origin/main...HEAD")
           rewritten=()
           while IFS= read -r file; do
             [ -n "$file" ] || continue
             [ -f "$file" ] || continue
             grep -Iq . "$file" || continue
-            CURRENT_VERSION="$current" DESIRED_VERSION="$VERSION" python3 - "$file" <<'PY'
+            DESIRED_VERSION="$VERSION" python3 - "$file" <<'PY'
           import os
           import re
           import sys
 
           path = sys.argv[1]
-          old = os.environ["CURRENT_VERSION"]
           new = os.environ["DESIRED_VERSION"]
+          version_pattern = re.compile(
+              r"(?<![0-9.])[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?![0-9.])"
+          )
           with open(path, encoding="utf-8") as handle:
               contents = handle.read()
-          updated = re.sub(re.escape(old), new, contents)
+          match = version_pattern.search(contents)
+          if match is None:
+              sys.exit(0)
+          old = match.group(0)
+          updated = contents.replace(old, new)
           if updated != contents:
               with open(path, "w", encoding="utf-8") as handle:
                   handle.write(updated)
+          print(f"{path}: {old} -> {new}")
           PY
             if ! git diff --quiet -- "$file"; then
               rewritten+=("$file")

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,9 @@
 # Runs release-please on push to main to create/update release PRs and GitHub Releases.
-# Also re-runs when the release PR title is edited to pick up version overrides.
+# Editing an existing release PR title applies an exact version override in place.
 # Built according to https://app.stainless.com/metronome/transition/docs/release
 #
-# Version override: edit the release PR title (e.g. "release: 5.0.0") and release-please
-# will re-run and update the PR with the new version.
+# Version override: edit the release PR title (e.g. "release: 3.11.0-alpha.1").
+# The override job rewrites only version-bearing files already changed by the PR.
 #
 # Required secret:
 #   RELEASE_PLEASE_TOKEN — fine-grained PAT with Contents:Read/Write and
@@ -23,26 +23,131 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-please-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-please:
-    # Run on push to main, or when a release PR title is edited
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.changes.title && startsWith(github.event.pull_request.title, 'release:'))
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - name: Parse version from PR title
-        id: parse
-        if: github.event_name == 'pull_request'
-        run: |
-          title="${{ github.event.pull_request.title }}"
-          # Extract version from "release: X.Y.Z" format
-          version=$(echo "$title" | sed -n 's/^release: *\(.*\)$/\1/p')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Parsed version override: $version"
-
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          release-as: ${{ steps.parse.outputs.version || '' }}
+
+  in-place-version-override:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.changes.title &&
+      startsWith(github.event.pull_request.title, 'release:')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - name: Parse and validate requested version
+        id: version
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          version=$(sed -n 's/^release: *\(.*\)$/\1/p' <<< "$TITLE")
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release title must use release: X.Y.Z or release: X.Y.Z-suffix"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Requested release version: $version"
+
+      - name: Checkout release PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BRANCH }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rewrite changed release files
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          current=$(jq -r '."."' .release-please-manifest.json)
+          if [ -z "$current" ] || [ "$current" = "null" ]; then
+            echo "::error::Could not determine the current release version"
+            exit 1
+          fi
+
+          changed=$(git diff --name-only --diff-filter=AM "origin/main...HEAD")
+          rewritten=()
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            [ -f "$file" ] || continue
+            grep -Iq . "$file" || continue
+            CURRENT_VERSION="$current" DESIRED_VERSION="$VERSION" python3 - "$file" <<'PY'
+          import os
+          import re
+          import sys
+
+          path = sys.argv[1]
+          old = os.environ["CURRENT_VERSION"]
+          new = os.environ["DESIRED_VERSION"]
+          with open(path, encoding="utf-8") as handle:
+              contents = handle.read()
+          updated = re.sub(re.escape(old), new, contents)
+          if updated != contents:
+              with open(path, "w", encoding="utf-8") as handle:
+                  handle.write(updated)
+          PY
+            if ! git diff --quiet -- "$file"; then
+              rewritten+=("$file")
+            fi
+          done <<< "$changed"
+
+          if [ "${#rewritten[@]}" -eq 0 ]; then
+            echo "::error::No current release version was found in the files changed by this PR"
+            exit 1
+          fi
+          printf 'Rewritten files: %s\n' "${rewritten[*]}"
+
+      - name: Commit and push exact version override
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "release-please[bot]"
+          git config user.email "release-please[bot]@users.noreply.github.com"
+          while IFS= read -r file; do
+            [ -n "$file" ] && git add -- "$file"
+          done < <(git diff --name-only --diff-filter=AM "origin/main...HEAD")
+          if git diff --cached --quiet; then
+            echo "No version changes needed."
+            exit 0
+          fi
+          git commit -m "chore(release): set version $VERSION"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"
+
+      - name: Comment selected version on release PR
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          marker='<!-- release-version-override -->'
+          body=$(cat <<EOF
+          $marker
+          Release version selected: **$VERSION**.
+
+          This release will be performed as **$VERSION**. To change it, edit this PR title to \\`release: X.Y.Z\\` (including any prerelease suffix); the workflow will update the release files in place.
+          EOF
+          )
+          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n 1)
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${existing}" -f body="$body" >/dev/null
+          else
+            gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body" >/dev/null
+          fi


### PR DESCRIPTION
## What this changes

Adds an in-PR release version override flow for release-please.

When an existing release PR title is edited to:

    release: 3.11.0-alpha.1

the workflow:

1. Reads and validates the exact version from the title.
2. Derives candidate files from the PR diff against `main`.
3. Rewrites the current release version only in those changed files.
4. Commits and pushes the update to the existing release PR branch.
5. Adds or updates one PR comment stating the selected version and how to change it.

The comment is idempotent and will not create duplicates.

This keeps normal release-please behavior on pushes to `main`, while title edits use the custom in-place override path. No filename allowlist is used; the files come from the release PR diff.

## Validation

Verified successfully in the private test mirror:

- [Test release PR #1](https://github.com/Metronome-Industries/metronome-ruby-test/pull/1)
- Title changed to `release: 3.11.0-alpha.1`
- Existing release PR files were rewritten in place.
- The selected-version comment was created.
